### PR TITLE
Support custom config on running tests as well (e.g. for decorators)

### DIFF
--- a/packages/react-scripts/config/jest/babelTransform.js
+++ b/packages/react-scripts/config/jest/babelTransform.js
@@ -9,8 +9,15 @@
 'use strict';
 
 const babelJest = require('babel-jest');
+const getCustomConfig = require('../custom-react-scripts/config');
+
+//Get custom configuration for injecting plugins, presets and loaders
+const customConfig = getCustomConfig(true);
 
 module.exports = babelJest.createTransformer({
-  presets: [require.resolve('babel-preset-react-app')],
+  presets: [require.resolve('babel-preset-react-app')].concat(
+    customConfig.babelPresets
+  ),
   babelrc: false,
+  plugins: customConfig.babelPlugins,
 });


### PR DESCRIPTION
I ran into errors when running my tests, with "@" as unexpected token.
This patch fixed the issue for me, using customConfig similar to the way it is used in the webpack configs.
