### PR TITLE
Add Autodll plugin and DllReferencePlugin capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "custom-react-scripts",
   "private": true,
   "scripts": {
     "build": "node packages/react-scripts/scripts/build.js",

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -44,6 +44,10 @@ For example ```styles.module.css``` or ```header.module.sass``` or ```footer.mod
 - ```REACT_APP_BABEL_STAGE_0=true``` - enable stage-0 Babel preset
 - ```REACT_APP_DECORATORS=true``` - enable decorators support
 
+#### Webpack
+- ```REACT_APP_WEBPACK_AUTODLL_PLUGIN=true``` - enable [autodll-webpack-plugin](https://github.com/asfktz/autodll-webpack-plugin) and configure via the `dll` entry in package.json.
+- ```REACT_APP_WEBPACK_DLL_REFERENCE=true``` - injects [DllReferencePlugin](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin) into the webpack plugins.  Configure via the `dllReference` entry in package.json.  You'll have to manually include the pre-built dlls in your html.
+
 #### Other
 - ```REACT_APP_WEBPACK_DASHBOARD=true``` - Enables connection to the[webpack-dashboard](https://github.com/FormidableLabs/electron-webpack-dashboard) Electron app (the app must be installed on local machine)
 

--- a/packages/react-scripts/config/custom-react-scripts/customizers/webpack-plugins.js
+++ b/packages/react-scripts/config/custom-react-scripts/customizers/webpack-plugins.js
@@ -2,6 +2,52 @@ const DashboardPlugin = require('webpack-dashboard/plugin');
 
 module.exports = {
   WEBPACK_DASHBOARD: {
-    get: () => new DashboardPlugin(),
+    get: isDev => isDev && new DashboardPlugin(),
+  },
+
+  WEBPACK_DLL_REFERENCE: {
+    get: isDev => {
+      // handled by hot reloader on dev
+      if (isDev) return;
+      const DllReferencePlugin = require('webpack').DllReferencePlugin;
+
+      // Read the dllReference configuration from package.json
+      const paths = require('../../paths');
+      const dllRefs = require(paths.appPackageJson).dllReference;
+      if (!dllRefs || !dllRefs.length) return;
+
+      return dllRefs.map(dll => {
+        return new DllReferencePlugin(
+          Object.assign(
+            {
+              context: paths.appPath,
+            },
+            dll
+          )
+        );
+      });
+    },
+  },
+
+  WEBPACK_AUTODLL_PLUGIN: {
+    get: () => {
+      const AutoDllPlugin = require('autodll-webpack-plugin').default;
+      // Read the dll configuration from package.json
+      const paths = require('../../paths');
+      const dllConfig = require(paths.appPackageJson).dll || { entry: {} };
+      if (!dllConfig.entry || Object.keys(dllConfig.entry).length === 0) return;
+
+      return new AutoDllPlugin(
+        Object.assign(
+          {
+            context: paths.appPath,
+            path: './dll',
+            filename: '[name].js',
+            inject: true,
+          },
+          dllConfig
+        )
+      );
+    },
   },
 };

--- a/packages/react-scripts/config/custom-react-scripts/utils/map-object.js
+++ b/packages/react-scripts/config/custom-react-scripts/utils/map-object.js
@@ -5,7 +5,9 @@ module.exports = function mapObject(obj, fn, toArray) {
       return final;
     }
     if (toArray) {
-      final.push(result);
+      Array.isArray(result)
+        ? (final = final.concat(result))
+        : final.push(result);
     }
     final[key] = result;
     return final;

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -288,6 +288,7 @@ module.exports = {
     // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    ...customConfig.webpackPlugins,
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -21,6 +21,7 @@
     "react-scripts": "./bin/react-scripts.js"
   },
   "dependencies": {
+    "autodll-webpack-plugin": "1.0.0",
     "autoprefixer": "7.1.2",
     "babel-core": "6.25.0",
     "babel-eslint": "7.2.3",


### PR DESCRIPTION
This enables DLL generation using the new [autodll-webpack-plugin](https://github.com/asfktz/autodll-webpack-plugin) - implementation is similar to this PR https://github.com/facebook/create-react-app/pull/2710.

I've also added a way to consume DLLs (from autodll or from other repos).