### PR TITLE
Fixed typo causing eslint warning

### DIFF
--- a/packages/react-scripts/template/src/App.js
+++ b/packages/react-scripts/template/src/App.js
@@ -97,7 +97,7 @@ class App extends Component {
                 - Enables connection to {' '}
                 <a
                   target="_blank"
-                  ref="noopener noreferrer"
+                  rel="noopener noreferrer"
                   href="https://github.com/FormidableLabs/electron-webpack-dashboard"
                 >
                   webpack-dashboard


### PR DESCRIPTION
Just creating a new project and running `npm start` causes ESLint to complain about a missing `rel="noopener noreferrer"` prop in one of the anchor tags. This is because there was a typo in `App.js` (was using `ref` instead of `rel`).

## Screenshot:

![Demo](https://dha4w82d62smt.cloudfront.net/items/1y45462p3B2m2j3k1M0K/Image%202018-06-27%20at%2010.07.41%20AM.png?X-CloudApp-Visitor-Id=2056150&v=519779c4)