### PR TITLE
Upgrade style-loader to v0.21.0 to enable HMR for css modules

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -60,7 +60,7 @@
     "react-error-overlay": "^1.0.10",
     "resolve": "1.6.0",
     "sass-loader": "^6.0.6",
-    "style-loader": "0.19.0",
+    "style-loader": "0.21.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "sw-precache-webpack-plugin": "0.11.4",


### PR DESCRIPTION
I've upgraded style-loader to address issue #144 where using CSS modules would not allow for HMR.

Here is the PR that was merged to allow for CSS modules to work with HMR on style-loader for reference: https://github.com/webpack-contrib/style-loader/pull/298

I don't know of any breaking changes this update would cause.